### PR TITLE
Add root redirect to frontend for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="0; url=frontend/index.html">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Uurroosterapp</title>
+  <link rel="canonical" href="frontend/index.html">
+  <script>
+    window.location.replace('frontend/index.html');
+  </script>
+</head>
+<body>
+  <p>De app wordt geladen. <a href="frontend/index.html">Klik hier als je niet automatisch wordt doorgestuurd.</a></p>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- GitHub Pages was showing the repository README instead of the web UI, so a root redirect is needed to load the frontend app automatically.

### Description
- Add a simple root `index.html` that redirects to `frontend/index.html` using a `meta refresh`, a `window.location.replace` script, and a fallback link for browsers without automatic redirects.

### Testing
- No automated tests were run because this is a static HTML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f98704880832094e36f438fa5e50d)