### PR TITLE
Fix week schedule regeneration, night-staffing checks and employee deletion

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -68,6 +68,7 @@ function initDOM() {
     DOM.employeeContract = document.getElementById('employee-contract');
     DOM.employeeActive = document.getElementById('employee-active');
     DOM.employeeCancelBtn = document.getElementById('employee-cancel-btn');
+    DOM.employeeDeleteBtn = document.getElementById('employee-delete-btn');
     DOM.generateScheduleBtn = document.getElementById('generate-schedule-btn');
 
     // Create tooltip element
@@ -226,6 +227,7 @@ function setupEventListeners() {
     });
     DOM.employeeForm.addEventListener('submit', handleEmployeeSubmit);
     DOM.employeeCancelBtn.addEventListener('click', closeEmployeeModal);
+    DOM.employeeDeleteBtn.addEventListener('click', handleEmployeeDelete);
     document.querySelectorAll('#employee-modal .modal-close').forEach(btn => {
         btn.addEventListener('click', closeEmployeeModal);
     });
@@ -1223,6 +1225,7 @@ function openAddEmployeeModal() {
     DOM.employeeModalTitle.textContent = 'Medewerker toevoegen';
     DOM.employeeForm.reset();
     DOM.employeeActive.checked = true;
+    DOM.employeeDeleteBtn.style.display = 'none';
     generateWeekScheduleHTML();
     resetWeekScheduleForm();
     DOM.employeeModal.classList.remove('hidden');
@@ -1244,6 +1247,7 @@ function openEditEmployeeModal(employeeId) {
     generateWeekScheduleHTML();
     loadWeekScheduleForm(1, employee.weekScheduleWeek1 || []);
     loadWeekScheduleForm(2, employee.weekScheduleWeek2 || []);
+    DOM.employeeDeleteBtn.style.display = 'inline-flex';
     DOM.employeeModal.classList.remove('hidden');
 }
 
@@ -1251,6 +1255,7 @@ function closeEmployeeModal() {
     DOM.employeeModal.classList.add('hidden');
     DOM.employeeForm.reset();
     AppState.editingEmployeeId = null;
+    DOM.employeeDeleteBtn.style.display = 'none';
 }
 
 function handleEmployeeSubmit(e) {
@@ -1278,6 +1283,22 @@ function handleEmployeeSubmit(e) {
     renderEmployees();
 }
 
+function handleEmployeeDelete() {
+    if (!AppState.editingEmployeeId) return;
+    const employee = getEmployee(AppState.editingEmployeeId);
+    if (!employee) return;
+
+    const relatedShifts = getShiftsByEmployee(employee.id).length;
+    const confirmMsg = `Weet je zeker dat je ${employee.name} wilt verwijderen?\n\nDit verwijdert ook ${relatedShifts} dienst${relatedShifts !== 1 ? 'en' : ''} en eventuele afwezigheden.`;
+
+    if (!confirm(confirmMsg)) return;
+
+    deleteEmployee(employee.id);
+    closeEmployeeModal();
+    renderEmployees();
+    renderPlanning();
+}
+
 // ===== WEEKROOSTER FUNCTIES =====
 
 function handleGenerateSchedule() {
@@ -1287,17 +1308,19 @@ function handleGenerateSchedule() {
     const startDate = weekDates[0];
     const endDate = weekDates[6];
 
-    if (!confirm(`Wil je de weekroosters genereren voor deze week (${formatDate(startDate)} t/m ${formatDate(endDate)})?\\n\\nDiensten worden alleen aangemaakt waar nog geen dienst is ingepland.`)) {
+    if (!confirm(`Wil je de weekroosters genereren voor deze week (${formatDate(startDate)} t/m ${formatDate(endDate)})?\\n\\nBestaande diensten in deze week worden verwijderd en opnieuw gegenereerd.`)) {
         return;
     }
 
+    const removedShifts = removeShiftsInDateRange(startDate, endDate);
     const totalShifts = applyWeekScheduleForAllEmployees(startDate, endDate);
 
-    if (totalShifts > 0) {
-        alert(`✅ ${totalShifts} dienst${totalShifts > 1 ? 'en' : ''} automatisch aangemaakt op basis van weekroosters!`);
+    if (totalShifts > 0 || removedShifts > 0) {
+        const removedLabel = removedShifts > 0 ? ` (${removedShifts} bestaande dienst${removedShifts !== 1 ? 'en' : ''} verwijderd)` : '';
+        alert(`✅ ${totalShifts} dienst${totalShifts !== 1 ? 'en' : ''} automatisch aangemaakt op basis van weekroosters!${removedLabel}`);
         renderPlanning();
     } else {
-        alert('Geen nieuwe diensten aangemaakt. Alle dagen zijn al ingepland of medewerkers hebben geen weekrooster ingesteld.');
+        alert('Geen nieuwe diensten aangemaakt. Medewerkers hebben geen weekrooster ingesteld.');
     }
 }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -291,6 +291,7 @@
                 </div>
 
                 <div class="modal-actions">
+                    <button type="button" class="btn btn-danger" id="employee-delete-btn" style="display: none; margin-right: auto;">Verwijderen</button>
                     <button type="button" class="btn btn-secondary" id="employee-cancel-btn">Annuleren</button>
                     <button type="submit" class="btn btn-primary">Opslaan</button>
                 </div>

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -68,6 +68,7 @@ function initDOM() {
     DOM.employeeContract = document.getElementById('employee-contract');
     DOM.employeeActive = document.getElementById('employee-active');
     DOM.employeeCancelBtn = document.getElementById('employee-cancel-btn');
+    DOM.employeeDeleteBtn = document.getElementById('employee-delete-btn');
     DOM.generateScheduleBtn = document.getElementById('generate-schedule-btn');
 
     // Create tooltip element
@@ -226,6 +227,7 @@ function setupEventListeners() {
     });
     DOM.employeeForm.addEventListener('submit', handleEmployeeSubmit);
     DOM.employeeCancelBtn.addEventListener('click', closeEmployeeModal);
+    DOM.employeeDeleteBtn.addEventListener('click', handleEmployeeDelete);
     document.querySelectorAll('#employee-modal .modal-close').forEach(btn => {
         btn.addEventListener('click', closeEmployeeModal);
     });
@@ -1223,6 +1225,7 @@ function openAddEmployeeModal() {
     DOM.employeeModalTitle.textContent = 'Medewerker toevoegen';
     DOM.employeeForm.reset();
     DOM.employeeActive.checked = true;
+    DOM.employeeDeleteBtn.style.display = 'none';
     generateWeekScheduleHTML();
     resetWeekScheduleForm();
     DOM.employeeModal.classList.remove('hidden');
@@ -1244,6 +1247,7 @@ function openEditEmployeeModal(employeeId) {
     generateWeekScheduleHTML();
     loadWeekScheduleForm(1, employee.weekScheduleWeek1 || []);
     loadWeekScheduleForm(2, employee.weekScheduleWeek2 || []);
+    DOM.employeeDeleteBtn.style.display = 'inline-flex';
     DOM.employeeModal.classList.remove('hidden');
 }
 
@@ -1251,6 +1255,7 @@ function closeEmployeeModal() {
     DOM.employeeModal.classList.add('hidden');
     DOM.employeeForm.reset();
     AppState.editingEmployeeId = null;
+    DOM.employeeDeleteBtn.style.display = 'none';
 }
 
 function handleEmployeeSubmit(e) {
@@ -1278,6 +1283,22 @@ function handleEmployeeSubmit(e) {
     renderEmployees();
 }
 
+function handleEmployeeDelete() {
+    if (!AppState.editingEmployeeId) return;
+    const employee = getEmployee(AppState.editingEmployeeId);
+    if (!employee) return;
+
+    const relatedShifts = getShiftsByEmployee(employee.id).length;
+    const confirmMsg = `Weet je zeker dat je ${employee.name} wilt verwijderen?\n\nDit verwijdert ook ${relatedShifts} dienst${relatedShifts !== 1 ? 'en' : ''} en eventuele afwezigheden.`;
+
+    if (!confirm(confirmMsg)) return;
+
+    deleteEmployee(employee.id);
+    closeEmployeeModal();
+    renderEmployees();
+    renderPlanning();
+}
+
 // ===== WEEKROOSTER FUNCTIES =====
 
 function handleGenerateSchedule() {
@@ -1287,17 +1308,19 @@ function handleGenerateSchedule() {
     const startDate = weekDates[0];
     const endDate = weekDates[6];
 
-    if (!confirm(`Wil je de weekroosters genereren voor deze week (${formatDate(startDate)} t/m ${formatDate(endDate)})?\\n\\nDiensten worden alleen aangemaakt waar nog geen dienst is ingepland.`)) {
+    if (!confirm(`Wil je de weekroosters genereren voor deze week (${formatDate(startDate)} t/m ${formatDate(endDate)})?\\n\\nBestaande diensten in deze week worden verwijderd en opnieuw gegenereerd.`)) {
         return;
     }
 
+    const removedShifts = removeShiftsInDateRange(startDate, endDate);
     const totalShifts = applyWeekScheduleForAllEmployees(startDate, endDate);
 
-    if (totalShifts > 0) {
-        alert(`✅ ${totalShifts} dienst${totalShifts > 1 ? 'en' : ''} automatisch aangemaakt op basis van weekroosters!`);
+    if (totalShifts > 0 || removedShifts > 0) {
+        const removedLabel = removedShifts > 0 ? ` (${removedShifts} bestaande dienst${removedShifts !== 1 ? 'en' : ''} verwijderd)` : '';
+        alert(`✅ ${totalShifts} dienst${totalShifts !== 1 ? 'en' : ''} automatisch aangemaakt op basis van weekroosters!${removedLabel}`);
         renderPlanning();
     } else {
-        alert('Geen nieuwe diensten aangemaakt. Alle dagen zijn al ingepland of medewerkers hebben geen weekrooster ingesteld.');
+        alert('Geen nieuwe diensten aangemaakt. Medewerkers hebben geen weekrooster ingesteld.');
     }
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -291,6 +291,7 @@
                 </div>
 
                 <div class="modal-actions">
+                    <button type="button" class="btn btn-danger" id="employee-delete-btn" style="display: none; margin-right: auto;">Verwijderen</button>
                     <button type="button" class="btn btn-secondary" id="employee-cancel-btn">Annuleren</button>
                     <button type="submit" class="btn btn-primary">Opslaan</button>
                 </div>


### PR DESCRIPTION
### Motivation
- Remove stale shifts before regenerating week schedules so generated rosters reflect current week settings. 
- Fix incorrect time arithmetic around midnight and enforce the configured minimum rest between shifts as an error. 
- Make night staffing checks respect configured minimums and provide warnings when undersubscribed. 
- Allow removing employees and clean up related data (shifts, availability, swap requests) from the store.

### Description
- Replace fragile `Date(date)` time parsing with `parseDateTime` that builds a `Date` from `YYYY-MM-DD` parts to avoid timezone/rollover errors and correctly compute overnight spans using `getShiftEndDateTime` and `getHoursBetweenShifts` (uses minutes internally). 
- Make rest-rule enforcement configurable via `DataStore.settings.rules.minHoursBetweenShifts` and treat violations below that threshold as an error in `validate11HourRule`. 
- Add night staffing validation in `validateMinimumStaffing` using `minStaffingNight` (honors `holidayRules` when applicable). 
- Add `removeShiftsInDateRange` and change `handleGenerateSchedule` to remove existing shifts for the generated week before re-applying week schedules, and update confirmation/alerts to report removed shifts. 
- Implement employee deletion UI and logic: add `employee-delete-btn`, `handleEmployeeDelete`, and update `deleteEmployee` to also remove related `shifts`, `availability`, and `swapRequests`; ensure UI shows/hides the button when editing/adding. 
- Mirror all runtime changes in the `docs/` build files so the demo site stays in sync.

### Testing
- Launched a local static server using `python -m http.server 8000` to host the frontend; server responded `200 OK`. 
- Ran Playwright UI scripts to exercise the login and employee modal flow; a screenshot of the login page was captured successfully but some Playwright runs navigating further timed out or returned `404`, so end-to-end interaction checks were only partially successful. 
- Performed local verification by grepping and opening modified files and committed the changes (`git commit` succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f9bf4be0c8320803b3d9dbb254496)