### PR TITLE
Add night shift overtime calculations

### DIFF
--- a/frontend/overtime.test.ts
+++ b/frontend/overtime.test.ts
@@ -1,0 +1,74 @@
+import {
+  calculateCreditedMinutesForNightShift,
+  calculateWeeklyOvertime,
+} from './overtime';
+
+type TestCallback = () => void;
+
+function describe(name: string, callback: TestCallback): void {
+  console.log(`\\n${name}`);
+  callback();
+}
+
+function it(name: string, callback: TestCallback): void {
+  try {
+    callback();
+    console.log(`  ✓ ${name}`);
+  } catch (error) {
+    console.error(`  ✗ ${name}`);
+    throw error;
+  }
+}
+
+function expectEqual(actual: number, expected: number, message: string): void {
+  if (actual !== expected) {
+    throw new Error(`${message}: expected ${expected}, received ${actual}`);
+  }
+}
+
+describe('calculateCreditedMinutesForNightShift', () => {
+  const date = '2024-05-06';
+
+  it('returns base credited minutes when no active night work', () => {
+    expectEqual(calculateCreditedMinutesForNightShift(date, 0), 480, 'case A');
+  });
+
+  it('adds doubled active night minutes', () => {
+    expectEqual(calculateCreditedMinutesForNightShift(date, 30), 540, 'case B');
+  });
+
+  it('adds doubled active night minutes for extended work', () => {
+    expectEqual(calculateCreditedMinutesForNightShift(date, 120), 720, 'case C');
+  });
+
+  it('caps credited active night minutes at 480 after doubling', () => {
+    expectEqual(calculateCreditedMinutesForNightShift(date, 360), 960, 'case D');
+  });
+
+  it('adds forfait minutes to the base credit', () => {
+    expectEqual(calculateCreditedMinutesForNightShift(date, 0, 15), 510, 'case E');
+  });
+});
+
+describe('calculateWeeklyOvertime', () => {
+  it('returns weekly overtime based on Monday week start', () => {
+    const creditedMinutesByDate = {
+      '2024-05-06': 480,
+      '2024-05-07': 480,
+      '2024-05-08': 480,
+      '2024-05-09': 480,
+      '2024-05-10': 480,
+    };
+
+    expectEqual(calculateWeeklyOvertime(creditedMinutesByDate, 2160, 'Mon'), 240, 'weekly');
+  });
+
+  it('handles shifts that cross midnight by grouping by start date week', () => {
+    const creditedMinutesByDate = {
+      '2024-05-05': 480,
+      '2024-05-06': 480,
+    };
+
+    expectEqual(calculateWeeklyOvertime(creditedMinutesByDate, 960, 'Mon'), 0, 'cross-midnight');
+  });
+});

--- a/frontend/overtime.ts
+++ b/frontend/overtime.ts
@@ -1,0 +1,82 @@
+export type WeekStartDay = 'Mon';
+
+type DateInput = Date | string;
+
+const BASE_ACTIVE_MINUTES = 480;
+const ACTIVE_NIGHT_CREDIT_CAP_MINUTES = 480;
+
+function parseDateInput(date: DateInput): Date {
+  if (date instanceof Date) {
+    return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  }
+
+  const [year, month, day] = date.split('-').map((value) => Number(value));
+  if (!year || !month || !day) {
+    throw new Error(`Invalid date input: ${date}`);
+  }
+
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+function getWeekStart(date: DateInput, weekStartsOn: WeekStartDay): Date {
+  const normalized = parseDateInput(date);
+  const dayOfWeek = normalized.getUTCDay();
+
+  if (weekStartsOn !== 'Mon') {
+    throw new Error(`Unsupported week start: ${weekStartsOn}`);
+  }
+
+  const offset = (dayOfWeek + 6) % 7;
+  const weekStart = new Date(normalized);
+  weekStart.setUTCDate(weekStart.getUTCDate() - offset);
+
+  return weekStart;
+}
+
+function toDateKey(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+}
+
+export function calculateCreditedMinutesForNightShift(
+  date: DateInput,
+  nightActiveMinutes: number,
+  forfaitMinutes = 0
+): number {
+  parseDateInput(date);
+
+  const creditedActiveNightMinutes = Math.min(
+    Math.max(0, nightActiveMinutes) * 2,
+    ACTIVE_NIGHT_CREDIT_CAP_MINUTES
+  );
+
+  return BASE_ACTIVE_MINUTES + creditedActiveNightMinutes + Math.max(0, forfaitMinutes);
+}
+
+export function calculateWeeklyOvertime(
+  creditedMinutesByDate: Record<string, number>,
+  contractMinutesPerWeek: number,
+  weekStartsOn: WeekStartDay
+): number {
+  const weekTotals = new Map<string, number>();
+
+  Object.entries(creditedMinutesByDate).forEach(([dateKey, minutes]) => {
+    const weekStart = getWeekStart(dateKey, weekStartsOn);
+    const weekStartKey = toDateKey(weekStart);
+    const currentTotal = weekTotals.get(weekStartKey) ?? 0;
+
+    weekTotals.set(weekStartKey, currentTotal + Math.max(0, minutes));
+  });
+
+  let overtimeMinutes = 0;
+
+  weekTotals.forEach((totalMinutes) => {
+    const weeklyOvertime = Math.max(0, totalMinutes - contractMinutesPerWeek);
+    overtimeMinutes += weeklyOvertime;
+  });
+
+  return overtimeMinutes;
+}


### PR DESCRIPTION
### Motivation
- Implement business rules for night-shift crediting where a sleeping night has a base credit and active-night minutes count double with a cap.
- Provide a way to aggregate credited minutes into weekly overtime based on a Monday week start.

### Description
- Add `frontend/overtime.ts` with `calculateCreditedMinutesForNightShift(date, nightActiveMinutes, forfaitMinutes?)` which returns base credited minutes (480), doubles `nightActiveMinutes`, caps the doubled active-night credit at 480 minutes, and adds optional `forfaitMinutes`.
- Add `calculateWeeklyOvertime(creditedMinutesByDate, contractMinutesPerWeek, weekStartsOn)` which groups credited days by the Monday-start week and sums overtime above `contractMinutesPerWeek`.
- Implement date parsing/normalization and `getWeekStart`/`toDateKey` helpers so ISO date strings and week grouping (including shifts crossing midnight via start-date grouping) are handled consistently.
- Add `frontend/overtime.test.ts` simple test harness and unit tests that exercise the required cases and weekly grouping.

### Testing
- Created unit tests in `frontend/overtime.test.ts` covering the required night-shift cases A–E and weekly overtime grouping scenarios.
- No automated tests were executed in CI here because no test runner was configured, so there are no test run results to report.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fc2358a608320880e4ad8d4cf88ee)