### PR TITLE
fix: dienst templates, nachtdienst uren, email optioneel

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -11377,23 +11377,8 @@ function closeTemplateModal() {
     if (modal) modal.remove();
 }
 
-function updateBuilderAssignmentTimes(oldStart, oldEnd, newStart, newEnd) {
-    const updateGrid = grid => {
-        Object.values(grid).forEach(dayGrid => {
-            Object.values(dayGrid).forEach(a => {
-                if (a.startTime === oldStart && a.endTime === oldEnd) {
-                    a.startTime = newStart;
-                    a.endTime = newEnd;
-                }
-            });
-        });
-    };
-    updateGrid(AppState.builderGrid);
-    Object.values(AppState.builderGridByWeek || {}).forEach(updateGrid);
-    AppState.builderIsDirty = true;
-}
 
-function saveTemplate(originalId) {
+async function saveTemplate(originalId) {
     const name = document.getElementById('template-name').value.trim();
     const start = document.getElementById('template-start').value;
     const end = document.getElementById('template-end').value;
@@ -11428,22 +11413,18 @@ function saveTemplate(originalId) {
         id = `${id}_${suffix}`;
     }
 
-    // Capture old times before overwriting (to update builder assignments below)
-    const oldTemplate = originalId ? DataStore.settings.shiftTemplates[originalId] : null;
-    const timesChanged = oldTemplate && (oldTemplate.start !== start || oldTemplate.end !== end);
-
     if (originalId && originalId !== id) {
         delete DataStore.settings.shiftTemplates[originalId];
     }
 
     DataStore.settings.shiftTemplates[id] = { name, start, end, icon };
     saveToStorage();
-    try { saveSettings('shiftTemplates', DataStore.settings.shiftTemplates); } catch (e) { console.error('Error saving templates:', e); }
-
-    // Update any builder assignments that still use the old template times
-    if (timesChanged) {
-        updateBuilderAssignmentTimes(oldTemplate.start, oldTemplate.end, start, end);
-        if (AppState.currentView === 'builder') renderBuilder();
+    try {
+        await saveSettings('shiftTemplates', DataStore.settings.shiftTemplates);
+    } catch (e) {
+        console.error('Error saving templates:', e);
+        showToast('Fout bij opslaan template', 'error');
+        return;
     }
 
     closeTemplateModal();

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -9880,7 +9880,7 @@ function showEditAccountModal(user, teams, onSave) {
                         </div>
                         <div class="form-group flex-1">
                             <label for="edit-user-email">Email</label>
-                            <input type="email" id="edit-user-email" class="form-input" value="${escapeHtml(user.email)}" required />
+                            <input type="email" id="edit-user-email" class="form-input" value="${escapeHtml(user.email || '')}" placeholder="Optioneel — welkomstmail wordt gestuurd bij invullen" />
                         </div>
                     </div>
                     <div class="form-row d-flex gap-10">
@@ -9945,18 +9945,13 @@ function showEditAccountModal(user, teams, onSave) {
             showToast('Naam is verplicht', 'warning');
             return;
         }
-        if (!newEmail) {
-            showToast('Email is verplicht', 'warning');
-            return;
-        }
-
         try {
             const emailNotif = form.querySelector('#edit-user-email-notif').checked;
             await apiFetch(`/admin/users/${user.id}`, {
                 method: 'PATCH',
                 body: JSON.stringify({
                     name: newName,
-                    email: newEmail,
+                    email: newEmail || null,
                     role: newRole,
                     team_id: newTeamId,
                     mainTeam: newTeamId,

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -11377,6 +11377,22 @@ function closeTemplateModal() {
     if (modal) modal.remove();
 }
 
+function updateBuilderAssignmentTimes(oldStart, oldEnd, newStart, newEnd) {
+    const updateGrid = grid => {
+        Object.values(grid).forEach(dayGrid => {
+            Object.values(dayGrid).forEach(a => {
+                if (a.startTime === oldStart && a.endTime === oldEnd) {
+                    a.startTime = newStart;
+                    a.endTime = newEnd;
+                }
+            });
+        });
+    };
+    updateGrid(AppState.builderGrid);
+    Object.values(AppState.builderGridByWeek || {}).forEach(updateGrid);
+    AppState.builderIsDirty = true;
+}
+
 function saveTemplate(originalId) {
     const name = document.getElementById('template-name').value.trim();
     const start = document.getElementById('template-start').value;
@@ -11412,6 +11428,10 @@ function saveTemplate(originalId) {
         id = `${id}_${suffix}`;
     }
 
+    // Capture old times before overwriting (to update builder assignments below)
+    const oldTemplate = originalId ? DataStore.settings.shiftTemplates[originalId] : null;
+    const timesChanged = oldTemplate && (oldTemplate.start !== start || oldTemplate.end !== end);
+
     if (originalId && originalId !== id) {
         delete DataStore.settings.shiftTemplates[originalId];
     }
@@ -11419,6 +11439,13 @@ function saveTemplate(originalId) {
     DataStore.settings.shiftTemplates[id] = { name, start, end, icon };
     saveToStorage();
     try { saveSettings('shiftTemplates', DataStore.settings.shiftTemplates); } catch (e) { console.error('Error saving templates:', e); }
+
+    // Update any builder assignments that still use the old template times
+    if (timesChanged) {
+        updateBuilderAssignmentTimes(oldTemplate.start, oldTemplate.end, start, end);
+        if (AppState.currentView === 'builder') renderBuilder();
+    }
+
     closeTemplateModal();
     renderSettings();
 }

--- a/frontend/config/settings.js
+++ b/frontend/config/settings.js
@@ -42,9 +42,12 @@ window.DEFAULT_SETTINGS = {
     shiftTemplates: {
         vroeg: { start: '07:30', end: '16:00', name: 'Vroege dienst' },
         laat: { start: '16:00', end: '23:00', name: 'Late dienst' },
-        nacht: { start: '23:00', end: '09:00', name: 'Nachtdienst' },
+        nacht: { start: '18:00', end: '09:00', name: 'Nachtdienst' },
         lang: { start: '09:00', end: '21:00', name: 'Lange dienst' }
     },
+    // Forfait voor nachtdiensten: uren toegevoegd bovenop actieve uren vóór/na slaapvenster (23:00-07:00)
+    // Nacht 18:00-09:00 = 5u actief voor 23:00 + 2u actief na 07:00 + 5u15 forfait = 12u15
+    nachtForfait: 5.25,
     // Teams configuratie
     teams: {
         vlot1: { name: 'Vlot 1 (Begeleiding)', color: '#3b82f6' },

--- a/frontend/data.js
+++ b/frontend/data.js
@@ -225,7 +225,8 @@ async function loadDataFromAPI() {
             emailNotifications: apiSettings.email_notifications || DataStore.settings.emailNotifications,
             schoolYearStart: apiSettings.school_year_start || DataStore.settings.schoolYearStart,
             teamMeetings: apiSettings.team_meetings || DataStore.settings.teamMeetings,
-            coverageTeams: apiSettings.coverageTeams || DataStore.settings.coverageTeams
+            coverageTeams: apiSettings.coverageTeams || DataStore.settings.coverageTeams,
+            shiftTemplates: apiSettings.shiftTemplates || DataStore.settings.shiftTemplates
         });
 
         // Use schedule_drafts from dedicated table if available (overrides settings fallback)

--- a/frontend/data.js
+++ b/frontend/data.js
@@ -226,7 +226,8 @@ async function loadDataFromAPI() {
             schoolYearStart: apiSettings.school_year_start || DataStore.settings.schoolYearStart,
             teamMeetings: apiSettings.team_meetings || DataStore.settings.teamMeetings,
             coverageTeams: apiSettings.coverageTeams || DataStore.settings.coverageTeams,
-            shiftTemplates: apiSettings.shiftTemplates || DataStore.settings.shiftTemplates
+            shiftTemplates: apiSettings.shiftTemplates || DataStore.settings.shiftTemplates,
+            nachtForfait: apiSettings.nachtForfait ?? DataStore.settings.nachtForfait
         });
 
         // Use schedule_drafts from dedicated table if available (overrides settings fallback)
@@ -1034,19 +1035,33 @@ function calculateShiftHours(shift) {
     const start = parseDateTime(shift.date, shift.startTime);
     const end = getShiftEndDateTime(shift);
 
-    const diffMs = end - start;
-    let hours = diffMs / (1000 * 60 * 60);
-
     const sleepStart = parseDateTime(shift.date, '23:00');
     const sleepEnd = parseDateTime(shift.date, '07:00');
     sleepEnd.setDate(sleepEnd.getDate() + 1);
+
+    const [startHours] = shift.startTime.split(':').map(Number);
+    const [endHours] = shift.endTime.split(':').map(Number);
+
+    // Nachtdienst-forfait: dienst overspant slaapvenster (23:00-07:00)
+    // Formule: actieve uren vóór 23u + actieve uren na 07u + forfait
+    if (endHours < startHours && endHours >= 7) {
+        const nachtForfait = (DataStore.settings && DataStore.settings.nachtForfait != null)
+            ? DataStore.settings.nachtForfait
+            : 5.25;
+        const beforeSleep = Math.max(0, (Math.min(end.getTime(), sleepStart.getTime()) - start.getTime()) / (1000 * 60 * 60));
+        const afterSleep = Math.max(0, (end.getTime() - sleepEnd.getTime()) / (1000 * 60 * 60));
+        return beforeSleep + afterSleep + nachtForfait;
+    }
+
+    // Reguliere berekening: totaal minus slaapoverlap
+    const diffMs = end - start;
+    let hours = diffMs / (1000 * 60 * 60);
 
     const overlapStart = Math.max(start.getTime(), sleepStart.getTime());
     const overlapEnd = Math.min(end.getTime(), sleepEnd.getTime());
 
     if (overlapEnd > overlapStart) {
-        const sleepMs = overlapEnd - overlapStart;
-        hours -= sleepMs / (1000 * 60 * 60);
+        hours -= (overlapEnd - overlapStart) / (1000 * 60 * 60);
     }
 
     return Math.max(0, hours);

--- a/frontend/data.js
+++ b/frontend/data.js
@@ -983,6 +983,32 @@ async function acceptTakeoverRequest(id, responseNotes) {
 
 // ===== SETTINGS FUNCTIES =====
 
+async function refreshSettings() {
+    try {
+        const settingsData = await dataApiFetch('/settings');
+        const apiSettings = settingsData.settings || {};
+        DataStore.settings = normalizeSettings({
+            ...DataStore.settings,
+            ...apiSettings.general,
+            teams: apiSettings.teams || DataStore.settings.teams,
+            rules: apiSettings.rules || DataStore.settings.rules,
+            holidayPeriods: apiSettings.holidayPeriods || DataStore.settings.holidayPeriods,
+            holidayRules: apiSettings.holidayRules || DataStore.settings.holidayRules,
+            responsibleRotation: apiSettings.responsibleRotation || DataStore.settings.responsibleRotation,
+            schedule_templates: apiSettings.schedule_templates || DataStore.settings.schedule_templates || [],
+            schedulePattern: apiSettings.schedule_pattern || DataStore.settings.schedulePattern,
+            emailNotifications: apiSettings.email_notifications || DataStore.settings.emailNotifications,
+            schoolYearStart: apiSettings.school_year_start || DataStore.settings.schoolYearStart,
+            teamMeetings: apiSettings.team_meetings || DataStore.settings.teamMeetings,
+            coverageTeams: apiSettings.coverageTeams || DataStore.settings.coverageTeams,
+            shiftTemplates: apiSettings.shiftTemplates || DataStore.settings.shiftTemplates,
+            nachtForfait: apiSettings.nachtForfait ?? DataStore.settings.nachtForfait
+        });
+    } catch (err) {
+        console.error('Fout bij herladen settings:', err);
+    }
+}
+
 async function saveSettings(key, value) {
     try {
         await dataApiFetch(`/settings/${key}`, {


### PR DESCRIPTION
## Samenvatting

- **Dienst templates laden uit DB**: wijzigingen in Instellingen → Dienst templates werden niet opgeslagen in de database (`shiftTemplates` ontbrak in de settings-merge bij het laden). Na de fix worden templates correct geladen en bewaard.
- **saveTemplate async**: de opslag naar de DB werd niet awaited, waardoor een mislukte save stilletjes werd genegeerd en de template na herladen terugsprong naar de oude waarde. Nu correct async met foutmelding bij mislukking.
- **Nachtdienst uren = 12u15**: nachtdiensten (18:00–09:00) toonden 5u. Nieuwe berekening: actieve uren vóór 23:00 (5u) + actieve uren na 07:00 (2u) + nachtforfait 5u15 = 12u15. Detectie op basis van midnight-crossing en einduur ≥ 07:00.
- **Email optioneel bij medewerker bewerken**: het bewerkformulier voor medewerkers in de admin panel vereiste verplicht een email. `required`-attribuut en validatie verwijderd zodat accounts zonder email kunnen worden opgeslagen (conform bestaand beleid).
- **refreshSettings geïmplementeerd**: ontbrekende functie toegevoegd zodat aanroepen in de codebase niet langer crashen.