### PR TITLE
v1.0.7 — Planning-controls kaart verborgen op mobiel, filters opgeruimd

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uurroosterapp-backend",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": true,
   "main": "src/server.js",
   "scripts": {

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -7547,6 +7547,44 @@ body[data-view-mode="day"] .timeline-day-cell {
         font-size: 14px;
     }
 
+    /* ===== PLANNING CONTROLS OP MOBIEL ===== */
+    /* Verberg de kaart-stijl standaard — zichtbaar zodra filters uitgevouwen zijn */
+    .planning-controls {
+        background: transparent !important;
+        box-shadow: none !important;
+        border-radius: 0 !important;
+        padding: 0 !important;
+        margin-bottom: 8px !important;
+        gap: 0 !important;
+    }
+
+    /* Herstel kaart-stijl wanneer de filterrij zichtbaar is */
+    .planning-controls:has(#planning-filters-row:not(.hidden)) {
+        background: var(--surface-color) !important;
+        box-shadow: var(--shadow-sm) !important;
+        border-radius: var(--radius-lg) !important;
+        padding: 12px 16px !important;
+        margin-bottom: 16px !important;
+        gap: 10px !important;
+    }
+
+    /* Filterrij: verticaal stapelen op mobiel */
+    #planning-filters-row {
+        flex-direction: column !important;
+        align-items: flex-start !important;
+        gap: 8px !important;
+    }
+
+    #planning-filters-row .planning-filter-buttons {
+        margin-left: 0 !important;
+        flex-wrap: wrap !important;
+        gap: 8px !important;
+    }
+
+    #planning-filters-row #team-toggles {
+        width: 100% !important;
+    }
+
     /* ===== MOBILE DAY VIEW FOR PLANNING ===== */
 
     /* Op kleine schermen: verberg beide weergave-knoppen, alleen dagweergave beschikbaar */


### PR DESCRIPTION
## v1.0.7

### 🐛 Fix: Planning-controls kaart zichtbaar op mobiel zonder inhoud

De witte kaart (achtergrond, schaduw, afgeronde hoeken) van de planningscontroles was altijd zichtbaar op mobiel, ook als enkel de datumnavigatie erin stond en de Week/Dag-knoppen al verborgen waren. Dit gaf een lege container-look.

**Oplossing:**
- Planning-controls kaart is transparant op mobiel (geen achtergrond, geen schaduw)
- Kaart-stijl wordt automatisch hersteld via CSS `:has()` zodra de filterrij zichtbaar is
- Datumnavigatie (pijltjes + periode-tekst) blijft altijd zichtbaar, gewoon zonder kaart-wrapper

---

### ✨ Verbetering: Schonere filterlay-out op mobiel

De filterrij (team-knoppen + Bezetting/verberg-toggle) stond rommelig op kleine schermen door `margin-left: auto` en ontbrekende wrap.

**Oplossing:**
- Filterrij stapelt nu verticaal op mobiel
- Team-knoppen bovenaan, filterknoppen eronder — beide links uitgelijnd
- Filterknoppen wikkelen correct bij meerdere items

---

### 🔧 Versie
`1.0.6` → `1.0.7`