### PR TITLE
ux: verberg undo/redo knoppen uit navigatiebalk

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -102,10 +102,6 @@
             <div class="view-header">
                 <h2>Roosterplanning</h2>
                 <div class="header-actions">
-                    <div class="undo-redo-controls">
-                        <button id="undo-btn" class="btn btn-sm btn-secondary" disabled title="Ongedaan maken (Ctrl+Z)"><i data-lucide="undo-2" class="lucide-sm"></i> Ongedaan</button>
-                        <button id="redo-btn" class="btn btn-sm btn-secondary" disabled title="Opnieuw (Ctrl+Y)">Opnieuw <i data-lucide="redo-2" class="lucide-sm"></i></button>
-                    </div>
                     <button id="add-shift-btn" class="btn btn-primary btn-primary-lg"><i data-lucide="plus" class="lucide-sm"></i> Dienst toevoegen</button>
                 </div>
                 <button id="planning-controls-toggle" class="btn btn-sm btn-secondary active" title="Filters tonen/verbergen"><i data-lucide="sliders-horizontal" class="lucide-sm"></i> Filters</button>


### PR DESCRIPTION
Undo/redo knoppen verwijderd uit de navigatiebalk. Ctrl+Z en Ctrl+Y blijven gewoon werken via de UndoManager.\n\nhttps://claude.ai/code/session_01MTLkstjcaGZFP7FZCoD4mX

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTLkstjcaGZFP7FZCoD4mX)_