### PR TITLE
fix: shift-modal herfrendert na opslaan/verwijderen activiteit

### DIFF
--- a/frontend/app-shifts.js
+++ b/frontend/app-shifts.js
@@ -1085,6 +1085,8 @@ async function handleActivitySubmit(e) {
         }
         closeActivityModal();
         renderPlanning();
+        // Herrender de open shift-modal zodat de nieuwe activiteit meteen zichtbaar is
+        if (AppState.editingShiftId) openEditShiftModal(AppState.editingShiftId);
         showToast('Activiteit opgeslagen', 'success');
     } catch (error) {
         showToast('Fout bij opslaan: ' + getUserFriendlyError(error), 'error');
@@ -1100,6 +1102,7 @@ async function handleActivityDelete() {
         await deleteActivity(parseInt(id, 10));
         closeActivityModal();
         renderPlanning();
+        if (AppState.editingShiftId) openEditShiftModal(AppState.editingShiftId);
         showToast('Activiteit verwijderd', 'success');
     } catch (error) {
         showToast('Fout bij verwijderen: ' + getUserFriendlyError(error), 'error');


### PR DESCRIPTION
Na het opslaan of verwijderen van een activiteit werd de shift-modal niet bijgewerkt. De activiteit was wel correct opgeslagen maar pas zichtbaar na sluiten en heropenen van de modal. Fix: `openEditShiftModal()` aanroepen na de actie zodat de modal meteen de nieuwe state toont.\n\nhttps://claude.ai/code/session_01MTLkstjcaGZFP7FZCoD4mX

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTLkstjcaGZFP7FZCoD4mX)_