### PR TITLE
ux: vier home/planning verbeteringen

### DIFF
--- a/frontend/app-nav.js
+++ b/frontend/app-nav.js
@@ -115,7 +115,6 @@ function renderHome() {
     html += renderHomeAlerts(role);
     html += '<div class="home-grid">';
     html += renderHomeShifts(user);
-    html += renderHomeQuickActions(role);
     html += renderHomeWeekendInfo();
     html += renderHomeRequests(user, role);
     html += '</div>';
@@ -434,7 +433,10 @@ function renderHomeRequests(user, role) {
     let pendingRequests = (DataStore.swapRequests || []).filter(r => {
         if (r.status !== 'pending' && r.status !== 'pending_lead') return false;
 
-        if (isLeadOrAdmin) return true;
+        if (isLeadOrAdmin) {
+            // Leads zien enkel verzoeken die hun goedkeuring vereisen (pending_lead)
+            return r.status === 'pending_lead';
+        }
         // Medewerker: eigen requests + takeover requests van eigen team
         return r.requester_user_id === userId || r.target_user_id === userId ||
                (r.request_type === 'takeover' && r.requester_shift_team === userTeam);

--- a/frontend/app-shifts.js
+++ b/frontend/app-shifts.js
@@ -55,6 +55,21 @@ function renderShiftCard(shift) {
     </div>`;
 }
 
+function populateShiftTemplateDropdown() {
+    const sel = DOM.shiftTemplate;
+    if (!sel) return;
+    const templates = DataStore.settings.shiftTemplates || {};
+    sel.innerHTML = '<option value="">-- Kies template --</option>';
+    Object.entries(templates).forEach(([key, t]) => {
+        const label = t.name || key;
+        const times = ` (${t.start}–${t.end})`;
+        const opt = document.createElement('option');
+        opt.value = key;
+        opt.textContent = label + times;
+        sel.appendChild(opt);
+    });
+}
+
 function openAddShiftModal() {
     AppState.editingShiftId = null;
     DOM.shiftModalTitle.textContent = 'Dienst toevoegen';
@@ -62,6 +77,7 @@ function openAddShiftModal() {
     DOM.shiftValidationErrors.innerHTML = '';
     DOM.shiftDate.value = formatDateYYYYMMDD(new Date());
     DOM.shiftDeleteBtn.classList.add('hidden');
+    populateShiftTemplateDropdown();
 
     // Populate dropdown with filtered employees
     populateEmployeeDropdown();
@@ -145,8 +161,9 @@ function openShiftModal(shift, canEdit) {
     // Set modal title
     DOM.shiftModalTitle.textContent = canEdit ? 'Dienst bewerken' : 'Dienst bekijken';
 
-    // Populate employee dropdown
+    // Populate dropdowns
     populateEmployeeDropdown();
+    populateShiftTemplateDropdown();
 
     // Fill form with shift data
     DOM.shiftEmployee.value = shift.employeeId;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -270,11 +270,6 @@
                         <label for="shift-template">Template</label>
                         <select id="shift-template">
                             <option value="">-- Kies template --</option>
-                            <option value="vroeg">Vroege dienst (7:30-16:00)</option>
-                            <option value="laat">Late dienst (16:00-23:00)</option>
-                            <option value="nacht">Nachtdienst (23:00-9:00)</option>
-                            <option value="lang">Lange dienst (9:00-21:00)</option>
-                            <option value="custom">Aangepast</option>
                         </select>
                     </div>
                 </div>
@@ -485,7 +480,6 @@
                         <option value="verlof">Verlof</option>
                         <option value="ziek">Ziekte</option>
                         <option value="overuren">Overuren opnemen</option>
-                        <option value="vorming">Vorming/Opleiding</option>
                         <option value="andere">Andere</option>
                     </select>
                 </div>


### PR DESCRIPTION
- **Openstaande verzoeken**: leads/admins zien enkel verzoeken met status `pending_lead` (vereisen hun goedkeuring). `pending`-verzoeken tussen medewerkers onderling verschijnen niet meer.\n- **Snelle acties**: blok verwijderd van home page, ruimte vrijgemaakt voor verzoeken.\n- **Vorming/Opleiding**: optie verwijderd uit afwezigheidstypen (vervangen door activiteiten-feature).\n- **Shift templates**: dropdown in dienst-modal laadt nu dynamisch vanuit `DataStore.settings.shiftTemplates` ipv hardcoded opties.\n\nhttps://claude.ai/code/session_01MTLkstjcaGZFP7FZCoD4mX

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTLkstjcaGZFP7FZCoD4mX)_