### PR TITLE
ux: komende diensten klikbaar + activiteiten tonen op home

### DIFF
--- a/frontend/app-nav.js
+++ b/frontend/app-nav.js
@@ -139,6 +139,15 @@ function renderHome() {
         });
     });
 
+    // Shift items: navigate to that week in planning view
+    container.querySelectorAll('.home-shift-item[data-shift-date]').forEach(item => {
+        item.addEventListener('click', () => {
+            const dateStr = item.dataset.shiftDate;
+            setCurrentWeek(parseDateOnly(dateStr));
+            switchView('planning');
+        });
+    });
+
     // Attach request click handlers
     container.querySelectorAll('.home-request-item[data-action="view-swaps"]').forEach(item => {
         item.style.cursor = 'pointer';
@@ -379,13 +388,31 @@ function renderHomeShifts(user) {
             const teamName = teamSettings?.name || teamId || '';
             const teamColor = teamSettings?.color || '#64748b';
 
+            const dateStr = shift.date.split('T')[0];
+            const activities = typeof getActivitiesByEmployee === 'function'
+                ? getActivitiesByEmployee(userId, dateStr)
+                : (DataStore.activities || []).filter(a => String(a.userId) === String(userId) && a.date === dateStr);
+
+            let activitiesHtml = '';
+            if (activities.length > 0) {
+                const pills = activities.map(a => {
+                    const label = ACTIVITY_TYPE_LABELS_FULL[a.type] || a.type || 'Activiteit';
+                    const t = a.startTime || a.start_time || '';
+                    return `<span class="home-shift-activity-badge">${escapeHtml(label)}${t ? ' · ' + escapeHtml(t) : ''}</span>`;
+                }).join('');
+                activitiesHtml = `<div class="home-shift-activities">${pills}</div>`;
+            }
+
             shiftsHtml += `
-                <div class="home-shift-item ${isToday ? 'home-shift-today' : ''}">
+                <div class="home-shift-item ${isToday ? 'home-shift-today' : ''}" data-shift-date="${escapeHtml(dateStr)}">
                     <div class="home-shift-date">
                         <span class="home-shift-date-num">${dayNum}</span>
                         <span class="day-name">${isToday ? 'Vandaag' : escapeHtml(dayName)}</span>
                     </div>
-                    <div class="home-shift-time">${escapeHtml(startTime)} – ${escapeHtml(endTime)}</div>
+                    <div class="home-shift-details">
+                        <div class="home-shift-time">${escapeHtml(startTime)} – ${escapeHtml(endTime)}</div>
+                        ${activitiesHtml}
+                    </div>
                     <span class="home-shift-team" style="background:${escapeHtml(teamColor)}">${escapeHtml(teamName)}</span>
                 </div>
             `;

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1221,12 +1221,34 @@ textarea:focus-visible {
     margin-top: 2px;
 }
 
-.home-shift-time {
+.home-shift-details {
     flex: 1;
+    min-width: 0;
+}
+
+.home-shift-time {
     font-size: 1rem;
     color: var(--text-primary);
     font-weight: 600;
     font-family: 'SF Mono', 'Monaco', 'Courier New', monospace;
+}
+
+.home-shift-activities {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-top: 5px;
+}
+
+.home-shift-activity-badge {
+    font-size: 0.72rem;
+    font-weight: 500;
+    padding: 2px 8px;
+    border-radius: 10px;
+    background: rgba(37, 99, 235, 0.1);
+    color: var(--primary-color);
+    border: 1px solid rgba(37, 99, 235, 0.2);
+    font-family: inherit;
 }
 
 .home-shift-team {


### PR DESCRIPTION
## Summary

- Klikken op een dienst in "Mijn komende diensten" navigeert naar de bijbehorende week in de planningsweergave
- Activiteiten voor die dag (vergadering, overleg, afspraak, …) worden als kleine blauwe badges getoond onder de diensttijd

## Test plan

- [ ] Klik op een dienst in "mijn komende diensten" → planning opent op de juiste week
- [ ] Voeg een activiteit toe aan een shift → badge verschijnt op de homekaart
- [ ] Diensten zonder activiteiten zien er ongewijzigd uit
- [ ] Meerdere activiteiten op één dag worden naast elkaar getoond

https://claude.ai/code/session_01MTLkstjcaGZFP7FZCoD4mX

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTLkstjcaGZFP7FZCoD4mX)_