### PR TITLE
fix: activiteit badge toont van–tot tijd en opmerking, geen seconden

### DIFF
--- a/frontend/app-nav.js
+++ b/frontend/app-nav.js
@@ -397,8 +397,11 @@ function renderHomeShifts(user) {
             if (activities.length > 0) {
                 const pills = activities.map(a => {
                     const label = ACTIVITY_TYPE_LABELS_FULL[a.type] || a.type || 'Activiteit';
-                    const t = a.startTime || a.start_time || '';
-                    return `<span class="home-shift-activity-badge">${escapeHtml(label)}${t ? ' · ' + escapeHtml(t) : ''}</span>`;
+                    const tStart = (a.startTime || a.start_time || '').substring(0, 5);
+                    const tEnd = (a.endTime || a.end_time || '').substring(0, 5);
+                    const timeStr = tStart && tEnd ? ` · ${tStart}–${tEnd}` : tStart ? ` · ${tStart}` : '';
+                    const desc = a.description ? ` · ${a.description}` : '';
+                    return `<span class="home-shift-activity-badge">${escapeHtml(label)}${escapeHtml(timeStr)}${escapeHtml(desc)}</span>`;
                 }).join('');
                 activitiesHtml = `<div class="home-shift-activities">${pills}</div>`;
             }


### PR DESCRIPTION
Fixes in de activiteitenbadge op de home pagina:

- Toont nu zowel start- als eindtijd (bv. `10:00–11:00` i.p.v. alleen `10:00`)
- Opmerking/beschrijving wordt getoond na de tijd
- Seconden worden weggeknipt (`.substring(0, 5)`)

https://claude.ai/code/session_01MTLkstjcaGZFP7FZCoD4mX

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTLkstjcaGZFP7FZCoD4mX)_