### PR TITLE
fix: avatar en uitlog correct uitlijnen in collapsed sidebar

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -7383,7 +7383,15 @@ body[data-view-mode="day"] .timeline-day-cell {
         display: none;
     }
 
+    .sidebar-toggle-input:checked ~ .main-nav .user-menu {
+        flex-direction: column;
+        gap: 6px;
+        width: 100%;
+        align-items: center;
+    }
+
     .sidebar-toggle-input:checked ~ .main-nav .user-menu-trigger {
+        width: auto;
         padding: 2px;
     }
 


### PR DESCRIPTION
In de ingeklapte sidebar (64px) was er te weinig ruimte voor avatar + uitlog knop naast elkaar (samen ~76px). Ze stapelen nu verticaal zodat beide netjes gecentreerd zichtbaar zijn.

https://claude.ai/code/session_01MTLkstjcaGZFP7FZCoD4mX

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTLkstjcaGZFP7FZCoD4mX)_