### PR TITLE
feat: collapsible validatiegroepen vanaf 5 items

### DIFF
--- a/frontend/app-nav.js
+++ b/frontend/app-nav.js
@@ -340,12 +340,54 @@ function renderHomeAlerts(role) {
 
     if (warnings.length === 0) return '';
 
-    const items = warnings.map(w => `
+    const ALERT_COLLAPSE_AT = 5;
+    const alertCategoryConfig = [
+        { id: 'unstaffed', label: 'Onderbezetting', icon: 'users' },
+        { id: '11h', label: '11-uur schending', icon: 'clock' },
+        { id: 'conflict', label: 'Shift + afwezigheid', icon: 'calendar-x-2' },
+        { id: 'consec', label: 'Opeenvolgende diensten', icon: 'trending-up' },
+        { id: 'swaps', label: 'Ruilverzoeken', icon: 'arrow-left-right' },
+        { id: 'other', label: 'Overig', icon: 'alert-triangle' },
+    ];
+    const getAlertCategory = w => {
+        if (!w.key) return 'other';
+        if (w.key.startsWith('unstaffed:')) return 'unstaffed';
+        if (w.key.startsWith('11h:')) return '11h';
+        if (w.key.startsWith('shift-absence:')) return 'conflict';
+        if (w.key.startsWith('consecutive:')) return 'consec';
+        if (w.key === 'old-swaps') return 'swaps';
+        return 'other';
+    };
+    const alertGroups = new Map();
+    for (const cat of alertCategoryConfig) alertGroups.set(cat.id, []);
+    for (const w of warnings) alertGroups.get(getAlertCategory(w)).push(w);
+
+    const renderAlertItem = w => `
         <div class="alert-item alert-item--${w.level}"${w.date ? ` data-date="${w.date}"` : ''}>
             <i data-lucide="${w.level === 'error' ? 'alert-circle' : w.level === 'info' ? 'info' : 'alert-triangle'}" class="lucide-xs"></i>
             <span>${w.text}</span>
             ${w.key ? `<button class="alert-dismiss-btn" data-alert-key="${w.key}" title="Verberg"><i data-lucide="x" class="lucide-xs"></i></button>` : ''}
-        </div>`).join('');
+        </div>`;
+
+    let bodyHtml = '';
+    for (const cat of alertCategoryConfig) {
+        const catItems = alertGroups.get(cat.id);
+        if (!catItems || catItems.length === 0) continue;
+        if (catItems.length >= ALERT_COLLAPSE_AT) {
+            bodyHtml += `
+        <div class="alert-group alert-group--collapsed">
+            <button class="alert-group-header" onclick="this.closest('.alert-group').classList.toggle('alert-group--collapsed')">
+                <i data-lucide="${cat.icon}" class="lucide-xs"></i>
+                <span class="alert-group-label">${cat.label}</span>
+                <span class="alert-group-count">${catItems.length}</span>
+                <i data-lucide="chevron-down" class="lucide-xs alert-group-chevron"></i>
+            </button>
+            <div class="alert-group-body">${catItems.map(renderAlertItem).join('')}</div>
+        </div>`;
+        } else {
+            bodyHtml += catItems.map(renderAlertItem).join('');
+        }
+    }
 
     return `
         <div class="home-alerts home-alerts--collapsed mb-md">
@@ -355,7 +397,7 @@ function renderHomeAlerts(role) {
                 <span class="home-alerts-count">${warnings.length}</span>
                 <i data-lucide="chevron-down" class="lucide-sm home-alerts-chevron"></i>
             </button>
-            <div class="home-alerts-body">${items}</div>
+            <div class="home-alerts-body">${bodyHtml}</div>
         </div>`;
 }
 

--- a/frontend/app-planner.js
+++ b/frontend/app-planner.js
@@ -305,6 +305,23 @@ function buildIssueBreakdown(summary, issueType) {
         });
 }
 
+function renderIssueMessageList(messages) {
+    const COLLAPSE_AT = 5;
+    if (messages.length < COLLAPSE_AT) {
+        return `<ul>${messages.map(m => `<li>${escapeHtml(m)}</li>`).join('')}</ul>`;
+    }
+    const visible = messages.slice(0, COLLAPSE_AT - 1).map(m => `<li>${escapeHtml(m)}</li>`).join('');
+    const hidden = messages.slice(COLLAPSE_AT - 1).map(m => `<li>${escapeHtml(m)}</li>`).join('');
+    return `<ul>${visible}</ul>
+        <div class="issue-details-more">
+            <button class="issue-details-more-toggle" onclick="this.closest('.issue-details-more').classList.toggle('issue-details-more--open')">
+                <span class="show-more">Toon ${messages.length - (COLLAPSE_AT - 1)} meer <i data-lucide="chevron-down" class="lucide-xs"></i></span>
+                <span class="show-less">Toon minder <i data-lucide="chevron-up" class="lucide-xs"></i></span>
+            </button>
+            <ul class="issue-details-more-list">${hidden}</ul>
+        </div>`;
+}
+
 function openWarningDetailsModal() {
     if (!DOM.warningDetailsModal) return;
     DOM.warningDetailsList.innerHTML = '';
@@ -314,7 +331,6 @@ function openWarningDetailsModal() {
         DOM.warningDetailsList.innerHTML = '<p>Geen waarschuwingen gevonden voor deze periode.</p>';
     } else {
         DOM.warningDetailsList.innerHTML = breakdown.map(item => {
-            const messageItems = item.messages.map(message => `<li>${escapeHtml(message)}</li>`).join('');
             return `<div class="issue-details-item">
                 <div class="issue-details-header">
                     <span class="issue-details-rule">${escapeHtml(item.rule)}</span>
@@ -322,13 +338,14 @@ function openWarningDetailsModal() {
                 </div>
                 <div class="issue-details-messages">
                     <div class="issue-details-label">Context</div>
-                    <ul>${messageItems}</ul>
+                    ${renderIssueMessageList(item.messages)}
                 </div>
             </div>`;
         }).join('');
     }
 
     DOM.warningDetailsModal.classList.remove('hidden');
+    if (typeof lucide !== 'undefined') lucide.createIcons();
 }
 
 function closeWarningDetailsModal() {
@@ -345,7 +362,6 @@ function openErrorDetailsModal() {
         DOM.errorDetailsList.innerHTML = '<p>Geen fouten gevonden voor deze periode.</p>';
     } else {
         DOM.errorDetailsList.innerHTML = breakdown.map(item => {
-            const messageItems = item.messages.map(message => `<li>${escapeHtml(message)}</li>`).join('');
             return `<div class="issue-details-item">
                 <div class="issue-details-header">
                     <span class="issue-details-rule">${escapeHtml(item.rule)}</span>
@@ -353,13 +369,14 @@ function openErrorDetailsModal() {
                 </div>
                 <div class="issue-details-messages">
                     <div class="issue-details-label">Context</div>
-                    <ul>${messageItems}</ul>
+                    ${renderIssueMessageList(item.messages)}
                 </div>
             </div>`;
         }).join('');
     }
 
     DOM.errorDetailsModal.classList.remove('hidden');
+    if (typeof lucide !== 'undefined') lucide.createIcons();
 }
 
 function closeErrorDetailsModal() {

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1053,6 +1053,41 @@ textarea:focus-visible {
     line-height: 1;
 }
 .alert-dismiss-btn:hover { opacity: 1; background: rgba(0,0,0,0.06); }
+.alert-group {
+    border-bottom: 1px solid var(--border-color);
+}
+.alert-group:last-child { border-bottom: none; }
+.alert-group-header {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    padding: 9px 16px;
+    font-size: 13px;
+    font-weight: 600;
+    background: var(--bg-secondary, #f8fafc);
+    color: var(--text-secondary);
+    border: none;
+    cursor: pointer;
+    text-align: left;
+    transition: background 0.15s;
+}
+.alert-group-header:hover { background: var(--bg-hover, #f1f5f9); }
+.alert-group-label { flex: 1; }
+.alert-group-count {
+    background: var(--color-warning, #f59e0b);
+    color: #fff;
+    font-size: 11px;
+    font-weight: 700;
+    border-radius: 10px;
+    padding: 1px 7px;
+    line-height: 1.6;
+}
+.alert-group-chevron { transition: transform 0.2s; flex-shrink: 0; }
+.alert-group--collapsed .alert-group-chevron { transform: rotate(-90deg); }
+.alert-group--collapsed .alert-group-body { display: none; }
+.alert-group .alert-item { border-bottom: 1px solid var(--border-color); }
+.alert-group .alert-item:last-child { border-bottom: none; }
 .alert-item--warning {
     background: var(--alert-warning-bg);
     border-left: 3px solid var(--alert-warning-border);
@@ -1985,6 +2020,24 @@ body[data-view-mode="day"] .timeline-header {
     margin-bottom: 4px;
     color: #92400e;
 }
+.issue-details-more { margin-top: 2px; }
+.issue-details-more-toggle {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 12px;
+    color: var(--color-primary, #3b82f6);
+    padding: 2px 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+}
+.issue-details-more-toggle:hover { text-decoration: underline; }
+.issue-details-more-toggle .show-less { display: none; }
+.issue-details-more--open .show-more { display: none; }
+.issue-details-more--open .show-less { display: inline-flex; align-items: center; gap: 3px; }
+.issue-details-more-list { display: none; margin: 4px 0 0; padding-left: 18px; color: var(--text-secondary); font-size: 12px; }
+.issue-details-more--open .issue-details-more-list { display: block; }
 
 
 .alert {


### PR DESCRIPTION
## Samenvatting

Wanneer een validatiecategorie 5 of meer meldingen heeft, worden ze standaard ingeklapt weergegeven.

**Homepage (Meldingen):**
- Categorieën met ≥5 items (bijv. 8 onderbezette dagen) krijgen een klikbare groepsheader met categorienaam + teller badge
- Standaard ingeklapt, één klik toont alle items
- Categorieën: Onderbezetting, 11-uur schending, Shift + afwezigheid, Opeenvolgende diensten, Ruilverzoeken
- Categorieën met <5 items: ongewijzigd weergegeven (platte lijst)

**Planner validatiemodals (waarschuwingen / fouten):**
- Regelgroepen met ≥5 meldingen tonen de eerste 4 zichtbaar + "Toon X meer" knop
- Klik klapt de rest uit, klik opnieuw klapt in ("Toon minder")

## Bestanden
- `frontend/app-nav.js` — groepering + collapsible render logica
- `frontend/app-planner.js` — `renderIssueMessageList` helper + modals
- `frontend/styles.css` — `.alert-group` en `.issue-details-more` CSS

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTLkstjcaGZFP7FZCoD4mX)_