### PR TITLE
fix: dubbele tijdweergave in onderbezetting-melding

### DIFF
--- a/frontend/app-nav.js
+++ b/frontend/app-nav.js
@@ -252,7 +252,7 @@ function renderHomeAlerts(role) {
             if (!dismissedKeys.has(key)) {
                 const label = `${dayLabelsNL[d.getDay()]} ${formatDateShort(d)}`;
                 const text = badWindows.length === 1
-                    ? `${label}: onderbezet ${fmtH(badWindows[0].from)}–${fmtH(badWindows[0].to)}`
+                    ? `${label}: onderbezet`
                     : `${label}: ${badWindows.length} onderbezette tijdvensters`;
                 const detail = badWindows.map(w => `${fmtH(w.from)}–${fmtH(w.to)}: ${w.netto}/${w.min} mdw`).join('<br>');
                 warnings.push({ level: 'warning', date: dateStr, key, text, detail });


### PR DESCRIPTION
Tijdvenster stond zowel in de samenvattingstitel als in de uitklapbare detailtekst. Titel toont nu enkel `"Di 20 mei: onderbezet"`, detail bevat de tijden en aantallen.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTLkstjcaGZFP7FZCoD4mX)_