### PR TITLE
feat: iCalendar feed — shifts synchroniseren naar Google/Apple/Outlook agenda

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,15 @@ jobs:
             const fs = require('fs');
             const files = [
               'frontend/index.html',
-              'frontend/app.js',
+              'frontend/app-globals.js',
+              'frontend/app-nav.js',
+              'frontend/app-planner.js',
+              'frontend/app-shifts.js',
+              'frontend/app-employees.js',
+              'frontend/app-builder.js',
+              'frontend/app-settings.js',
+              'frontend/app-auth.js',
+              'frontend/app-init.js',
               'frontend/data.js',
               'frontend/validation.js',
               'frontend/drag-handler.js',
@@ -33,15 +41,16 @@ jobs:
 
       - name: Check frontend JS syntax
         run: |
-          node --check frontend/app.js
-          node --check frontend/data.js
-          node --check frontend/validation.js
-          node --check frontend/drag-handler.js
-          node --check frontend/config/settings.js
+          for f in frontend/app-*.js frontend/data.js frontend/validation.js frontend/drag-handler.js frontend/config/settings.js; do
+            node --check "$f"
+          done
           echo "Frontend JS syntax OK"
 
       - name: Install backend dependencies
         run: cd backend && npm install
+
+      - name: Run backend tests
+        run: cd backend && npm test
 
       - name: Check backend JS syntax
         run: |

--- a/backend/sql/schema.sql
+++ b/backend/sql/schema.sql
@@ -26,6 +26,7 @@ CREATE TABLE IF NOT EXISTS users (
   week_schedules JSONB DEFAULT NULL,
   email_notifications_enabled BOOLEAN DEFAULT true,
   onboarding_flags JSONB DEFAULT '{}',
+  ical_feed_token TEXT UNIQUE,
   created_at TIMESTAMP DEFAULT NOW()
 );
 

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -51,7 +51,8 @@ app.use(globalLimiter);
 
 // ===== DATE HELPER FUNCTIONS =====
 // Used by apply-schedule endpoint (replicates frontend data.js logic)
-const { getMonday, formatDateYYYYMMDD, parseLocalDate, getBelgianPublicHolidays, shiftsOverlapCheck, hoursBetweenShifts } = require('./utils');
+const crypto = require('crypto');
+const { getMonday, formatDateYYYYMMDD, parseLocalDate, getBelgianPublicHolidays, shiftsOverlapCheck, hoursBetweenShifts, formatICalDateTime } = require('./utils');
 
 // ===== VERSIONED MIGRATIONS =====
 // Each entry runs exactly once, tracked in the `migrations` table.
@@ -461,6 +462,12 @@ const MIGRATIONS = [
     up: async (client) => {
       await client.query(`ALTER TABLE shifts ADD COLUMN IF NOT EXISTS is_reserve BOOLEAN NOT NULL DEFAULT false`);
     }
+  },
+  {
+    name: '032_users_ical_feed_token',
+    up: async (client) => {
+      await client.query(`ALTER TABLE users ADD COLUMN IF NOT EXISTS ical_feed_token TEXT UNIQUE`);
+    }
   }
 ];
 
@@ -731,7 +738,8 @@ v1.get('/me', requireAuth, async (req, res) => {
                 week_schedule_week2 as "weekScheduleWeek2",
                 week_schedules as "weekSchedules",
                 email_notifications_enabled as "emailNotificationsEnabled",
-                onboarding_flags as "onboardingFlags"
+                onboarding_flags as "onboardingFlags",
+                ical_feed_token as "icalFeedToken"
          FROM users WHERE id = $1`,
         [req.user.id]
       );
@@ -821,6 +829,91 @@ v1.put('/me/email-preferences', requireAuth, async (req, res) => {
     res.status(500).json({ error: 'Server error' });
   }
 });
+
+// POST /me/ical-token - Genereer of reset persoonlijke iCal feed token
+v1.post('/me/ical-token', requireAuth, async (req, res) => {
+  try {
+    const token = crypto.randomUUID();
+    await pool.query('UPDATE users SET ical_feed_token = $1 WHERE id = $2', [token, req.user.id]);
+    await logAudit(req, 'UPDATE', 'user', req.user.id, { action: 'ical_token_reset' });
+    res.json({ token });
+  } catch (err) {
+    console.error('POST /me/ical-token error:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+// GET /calendar/:token.ics - Publieke iCal feed (token = auth)
+v1.get('/calendar/:token.ics', async (req, res) => {
+  try {
+    const userResult = await pool.query(
+      `SELECT id, name FROM users WHERE ical_feed_token = $1 AND active = true`,
+      [req.params.token]
+    );
+    if (!userResult.rows.length) return res.status(404).send('Not found');
+    const user = userResult.rows[0];
+
+    const from = new Date(); from.setDate(from.getDate() - 30);
+    const to   = new Date(); to.setDate(to.getDate() + 365);
+    const shiftsResult = await pool.query(
+      `SELECT s.id, s.date::text, s.start_time, s.end_time, s.team, s.notes,
+              t.name as team_name
+       FROM shifts s
+       LEFT JOIN teams t ON t.id = s.team
+       WHERE s.user_id = $1 AND s.date >= $2 AND s.date <= $3
+       ORDER BY s.date, s.start_time`,
+      [user.id, formatDateYYYYMMDD(from), formatDateYYYYMMDD(to)]
+    );
+
+    const now = new Date().toISOString().replace(/[-:.]/g, '').slice(0, 15) + 'Z';
+
+    const events = shiftsResult.rows.map(s => {
+      const dateStr = s.date.slice(0, 10);
+      const start = formatICalDateTime(dateStr, s.start_time);
+      let endDate = dateStr;
+      if (s.end_time <= s.start_time) {
+        const d = new Date(dateStr); d.setDate(d.getDate() + 1);
+        endDate = formatDateYYYYMMDD(d);
+      }
+      const end = formatICalDateTime(endDate, s.end_time);
+      const summary = icalEscape(s.team_name || s.team || 'Shift');
+      const lines = [
+        'BEGIN:VEVENT',
+        `UID:shift-${s.id}@hetvlot`,
+        `DTSTAMP:${now}`,
+        `DTSTART:${start}`,
+        `DTEND:${end}`,
+        `SUMMARY:${summary}`,
+      ];
+      if (s.notes) lines.push(`DESCRIPTION:${icalEscape(s.notes)}`);
+      lines.push('END:VEVENT');
+      return lines.join('\r\n');
+    }).join('\r\n');
+
+    const ical = [
+      'BEGIN:VCALENDAR',
+      'VERSION:2.0',
+      'PRODID:-//Het Vlot//Roosterplanning//NL',
+      'CALSCALE:GREGORIAN',
+      'METHOD:PUBLISH',
+      `X-WR-CALNAME:Rooster ${icalEscape(user.name)}`,
+      'X-WR-TIMEZONE:Europe/Brussels',
+      events,
+      'END:VCALENDAR',
+    ].join('\r\n');
+
+    res.set('Content-Type', 'text/calendar; charset=utf-8');
+    res.set('Cache-Control', 'no-cache');
+    res.send(ical);
+  } catch (err) {
+    console.error('GET /calendar/:token.ics error:', err);
+    res.status(500).send('Server error');
+  }
+});
+
+function icalEscape(str) {
+  return String(str || '').replace(/\\/g, '\\\\').replace(/;/g, '\\;').replace(/,/g, '\\,').replace(/\n/g, '\\n');
+}
 
 // PUT /me/onboarding-flags - Update onboarding flags (merge)
 v1.put('/me/onboarding-flags', requireAuth, async (req, res) => {

--- a/backend/src/utils.js
+++ b/backend/src/utils.js
@@ -136,7 +136,12 @@ function shiftsOverlapCheck(a, b) {
   return s1 < e2 && s2 < e1;
 }
 
+// iCal datetime: '2026-05-15' + '09:00' → '20260515T090000' (floating local time)
+function formatICalDateTime(dateStr, timeStr) {
+  return dateStr.replace(/-/g, '') + 'T' + timeStr.replace(':', '') + '00';
+}
+
 module.exports = {
   getMonday, formatDateYYYYMMDD, parseLocalDate, getEasterDate, getBelgianPublicHolidays,
-  parseShiftDateTime, getShiftEndDT, hoursBetweenShifts, shiftsOverlapCheck
+  parseShiftDateTime, getShiftEndDT, hoursBetweenShifts, shiftsOverlapCheck, formatICalDateTime
 };

--- a/frontend/app-employees.js
+++ b/frontend/app-employees.js
@@ -303,6 +303,28 @@ function renderProfile() {
                             </label>
                         </span>
                     </div>
+                    <div class="profile-meta-row profile-ical-row">
+                        <span class="profile-meta-label">Agenda koppeling</span>
+                        <span class="profile-meta-value profile-ical-value">
+                            ${user.icalFeedToken ? `
+                                <div class="profile-ical-url-row">
+                                    <input type="text" readonly class="form-input profile-ical-input" id="profile-ical-input" value="${escapeHtml(typeof API_URL !== 'undefined' ? API_URL : '')}/calendar/${escapeHtml(user.icalFeedToken)}.ics">
+                                    <button type="button" class="btn btn-secondary btn-xs" id="profile-ical-copy">
+                                        ${IconHelper.html('copy', 'xs')} Kopieer
+                                    </button>
+                                </div>
+                                <div class="profile-ical-help">Plak deze URL in Google Calendar, Apple Agenda of Outlook als "Abonneren op agenda".</div>
+                                <button type="button" class="btn btn-ghost btn-xs profile-ical-reset" id="profile-ical-reset">
+                                    ${IconHelper.html('refresh-cw', 'xs')} Nieuwe link genereren
+                                </button>
+                            ` : `
+                                <button type="button" class="btn btn-secondary btn-xs" id="profile-ical-activate">
+                                    ${IconHelper.html('calendar-plus', 'xs')} Agenda koppeling activeren
+                                </button>
+                                <div class="profile-ical-help">Synchroniseer je shifts naar Google Calendar, Apple Agenda of Outlook.</div>
+                            `}
+                        </span>
+                    </div>
                 </div>
             </div>
         </div>
@@ -332,6 +354,51 @@ function renderProfile() {
             } catch (error) {
                 emailToggle.checked = !emailToggle.checked;
                 showToast('Kon voorkeur niet opslaan: ' + error.message, 'error');
+            }
+        });
+    }
+
+    // iCal feed handlers
+    const icalActivateBtn = document.getElementById('profile-ical-activate');
+    if (icalActivateBtn) {
+        icalActivateBtn.addEventListener('click', async () => {
+            icalActivateBtn.disabled = true;
+            try {
+                const data = await dataApiFetch('/me/ical-token', { method: 'POST' });
+                AppState.currentUser.icalFeedToken = data.token;
+                sessionStorage.setItem('hetvlot_user', JSON.stringify(AppState.currentUser));
+                renderProfile();
+                showToast('Agenda koppeling geactiveerd', 'success');
+            } catch (e) {
+                icalActivateBtn.disabled = false;
+                showToast('Kon koppeling niet activeren: ' + e.message, 'error');
+            }
+        });
+    }
+    const icalCopyBtn = document.getElementById('profile-ical-copy');
+    if (icalCopyBtn) {
+        icalCopyBtn.addEventListener('click', () => {
+            const input = document.getElementById('profile-ical-input');
+            if (!input) return;
+            navigator.clipboard.writeText(input.value)
+                .then(() => showToast('Link gekopieerd', 'success'))
+                .catch(() => { input.select(); document.execCommand('copy'); showToast('Link gekopieerd', 'success'); });
+        });
+    }
+    const icalResetBtn = document.getElementById('profile-ical-reset');
+    if (icalResetBtn) {
+        icalResetBtn.addEventListener('click', async () => {
+            if (!confirm('Genereer een nieuwe link? De oude link werkt dan niet meer.')) return;
+            icalResetBtn.disabled = true;
+            try {
+                const data = await dataApiFetch('/me/ical-token', { method: 'POST' });
+                AppState.currentUser.icalFeedToken = data.token;
+                sessionStorage.setItem('hetvlot_user', JSON.stringify(AppState.currentUser));
+                renderProfile();
+                showToast('Nieuwe link gegenereerd', 'success');
+            } catch (e) {
+                icalResetBtn.disabled = false;
+                showToast('Kon link niet resetten: ' + e.message, 'error');
             }
         });
     }

--- a/frontend/app-nav.js
+++ b/frontend/app-nav.js
@@ -252,7 +252,7 @@ function renderHomeAlerts(role) {
             if (!dismissedKeys.has(key)) {
                 const label = `${dayLabelsNL[d.getDay()]} ${formatDateShort(d)}`;
                 const text = badWindows.length === 1
-                    ? `${label}: onderbezet ${fmtH(badWindows[0].from)}–${fmtH(badWindows[0].to)}`
+                    ? `${label}: onderbezet`
                     : `${label}: ${badWindows.length} onderbezette tijdvensters`;
                 const detail = badWindows.map(w => `${fmtH(w.from)}–${fmtH(w.to)}: ${w.netto}/${w.min} mdw`).join('<br>');
                 warnings.push({ level: 'warning', date: dateStr, key, text, detail });

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -5361,6 +5361,19 @@ body[data-view-mode="day"] .timeline-day-cell {
     background: #ecfdf3;
     color: #166534;
 }
+.profile-ical-row { align-items: flex-start; }
+.profile-ical-value { display: flex; flex-direction: column; gap: 6px; }
+.profile-ical-url-row { display: flex; gap: 6px; align-items: center; }
+.profile-ical-input {
+    font-size: 11px;
+    font-family: monospace;
+    min-width: 0;
+    flex: 1;
+    color: var(--text-secondary);
+}
+.profile-ical-help { font-size: 12px; color: var(--text-secondary); }
+.profile-ical-reset { opacity: 0.6; }
+.profile-ical-reset:hover { opacity: 1; }
 
 .form-actions {
     margin-top: 12px;


### PR DESCRIPTION
Closes #125

## Wat er gebouwd is

Elke medewerker kan hun shifts synchroniseren naar Google Calendar, Apple Agenda, Outlook of elke andere agenda-app via een persoonlijke iCal feed URL.

## Backend

- **Migratie 032**: `ical_feed_token TEXT UNIQUE` kolom op `users` tabel
- **`POST /api/v1/me/ical-token`** (ingelogd) — genereert of reset persoonlijk token via `crypto.randomUUID()`
- **`GET /api/v1/calendar/:token.ics`** (publiek, geen auth) — levert `.ics` bestand:
  - Shifts van -30 tot +365 dagen
  - Floating local time (geen UTC-conversie, werkt met elk toestel)
  - Overnight shifts correct afgehandeld (eindtijd < begintijd → volgende dag)
  - Stabiele `UID: shift-{id}@hetvlot` → updates ipv duplicaten in agenda
  - `SUMMARY`: teamnaam, `DESCRIPTION`: notities indien aanwezig
- **`GET /me`**: geeft `icalFeedToken` mee
- **`utils.js`**: `formatICalDateTime(dateStr, timeStr)` helper

## Frontend

In het eigen profiel (Account overzicht sectie):
- **Inactief**: "Agenda koppeling activeren" knop
- **Actief**: feed URL in readonly input + kopieerknop + "Nieuwe link genereren" (met bevestiging)
- Token wordt opgeslagen in `AppState.currentUser` + `sessionStorage`

## Testen

1. Profiel openen → "Agenda koppeling activeren"
2. URL kopiëren → open in browser → geldig iCal tekst
3. In Google Calendar: Andere agenda's → + via URL → plak de URL
4. "Nieuwe link genereren" → oude URL geeft 404, nieuwe werkt

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTLkstjcaGZFP7FZCoD4mX)_