### PR TITLE
fix: iCal feed URL toont volledige URL (API_BASE ipv API_URL)

### DIFF
--- a/frontend/app-employees.js
+++ b/frontend/app-employees.js
@@ -308,7 +308,7 @@ function renderProfile() {
                         <span class="profile-meta-value profile-ical-value">
                             ${user.icalFeedToken ? `
                                 <div class="profile-ical-url-row">
-                                    <input type="text" readonly class="form-input profile-ical-input" id="profile-ical-input" value="${escapeHtml(typeof API_URL !== 'undefined' ? API_URL : '')}/calendar/${escapeHtml(user.icalFeedToken)}.ics">
+                                    <input type="text" readonly class="form-input profile-ical-input" id="profile-ical-input" value="${escapeHtml(typeof API_BASE !== 'undefined' ? API_BASE : '')}/calendar/${escapeHtml(user.icalFeedToken)}.ics">
                                     <button type="button" class="btn btn-secondary btn-xs" id="profile-ical-copy">
                                         ${IconHelper.html('copy', 'xs')} Kopieer
                                     </button>


### PR DESCRIPTION
De iCal feed URL in het profiel toonde `/calendar/TOKEN.ics` (relatief) in plaats van de volledige URL. Apple/Google Calendar konden de feed niet valideren.

Oorzaak: verkeerde variabelenaam (`API_URL` bestaat niet, de juiste is `API_BASE` uit `config/settings.js`).

Na de fix toont de input: `https://uurrooster-app.onrender.com/api/v1/calendar/TOKEN.ics`

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTLkstjcaGZFP7FZCoD4mX)_