### PR TITLE
fix: API_BASE gebruikt window.location.origin ipv hardcoded Render URL

### DIFF
--- a/frontend/app-employees.js
+++ b/frontend/app-employees.js
@@ -308,7 +308,7 @@ function renderProfile() {
                         <span class="profile-meta-value profile-ical-value">
                             ${user.icalFeedToken ? `
                                 <div class="profile-ical-url-row">
-                                    <input type="text" readonly class="form-input profile-ical-input" id="profile-ical-input" value="${escapeHtml(typeof API_URL !== 'undefined' ? API_URL : '')}/calendar/${escapeHtml(user.icalFeedToken)}.ics">
+                                    <input type="text" readonly class="form-input profile-ical-input" id="profile-ical-input" value="${escapeHtml(typeof API_BASE !== 'undefined' ? API_BASE : '')}/calendar/${escapeHtml(user.icalFeedToken)}.ics">
                                     <button type="button" class="btn btn-secondary btn-xs" id="profile-ical-copy">
                                         ${IconHelper.html('copy', 'xs')} Kopieer
                                     </button>

--- a/frontend/config/settings.js
+++ b/frontend/config/settings.js
@@ -1,14 +1,14 @@
 // ===== GECENTRALISEERDE SETTINGS =====
 // Deze file is de centrale plek voor alle standaard instellingen.
 
-// Automatisch detecteren: lokaal = localhost, productie = Render URL
+// Automatisch detecteren: lokaal = localhost, productie = zelfde origin
 // Ook file:// protocol wordt als lokaal gezien (voor development)
 if (window.location.hostname === 'localhost' ||
     window.location.hostname === '127.0.0.1' ||
     window.location.protocol === 'file:') {
     window.API_BASE = 'http://localhost:3001/api/v1';
 } else {
-    window.API_BASE = 'https://uurrooster-app.onrender.com/api/v1';
+    window.API_BASE = window.location.origin + '/api/v1';
 }
 
 window.DEFAULT_SETTINGS = {


### PR DESCRIPTION
$(cat <<'EOF'
## Probleem

`API_BASE` was hardcoded op `https://uurrooster-app.onrender.com/api/v1`. Dat klopt niet meer als de app via een custom domein (bijv. `vlot-dashboard.site`) wordt bezocht — de iCal-feed URL en alle API-calls zouden dan naar de verkeerde origin verwijzen.

## Oplossing

`window.location.origin + '/api/v1'` gebruiken voor productie. Dit werkt automatisch met elk domein zonder extra configuratie.

| Omgeving | Resultaat |
|----------|-----------|
| `localhost` | `http://localhost:3001/api/v1` (ongewijzigd) |
| `vlot-dashboard.site` | `https://vlot-dashboard.site/api/v1` |
| `uurrooster-app.onrender.com` | `https://uurrooster-app.onrender.com/api/v1` |

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTLkstjcaGZFP7FZCoD4mX)_
EOF
)