### PR TITLE
fix: herstel login — API_BASE naar backend URL + CORS voor vlot-dashboard.site

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -32,9 +32,12 @@ const DEFAULT_RESET_PASSWORD = process.env.DEFAULT_RESET_PASSWORD;
 app.use(helmet());
 app.set('trust proxy', 1);
 
-// CORS: restrict to frontend origin in production, open in development
+// CORS: restrict to frontend origin(s) in production, open in development
+const allowedOrigins = process.env.FRONTEND_URL
+  ? process.env.FRONTEND_URL.split(',').map(o => o.trim())
+  : ['https://uurrooster-frontend.onrender.com', 'https://vlot-dashboard.site'];
 const corsOptions = process.env.NODE_ENV === 'production'
-  ? { origin: process.env.FRONTEND_URL || 'https://uurrooster-frontend.onrender.com', credentials: true }
+  ? { origin: (origin, cb) => cb(null, !origin || allowedOrigins.includes(origin)), credentials: true }
   : {};
 app.use(cors(corsOptions));
 app.use(express.json());

--- a/frontend/config/settings.js
+++ b/frontend/config/settings.js
@@ -1,14 +1,14 @@
 // ===== GECENTRALISEERDE SETTINGS =====
 // Deze file is de centrale plek voor alle standaard instellingen.
 
-// Automatisch detecteren: lokaal = localhost, productie = zelfde origin
+// Automatisch detecteren: lokaal = localhost, productie = backend API URL
 // Ook file:// protocol wordt als lokaal gezien (voor development)
 if (window.location.hostname === 'localhost' ||
     window.location.hostname === '127.0.0.1' ||
     window.location.protocol === 'file:') {
     window.API_BASE = 'http://localhost:3001/api/v1';
 } else {
-    window.API_BASE = window.location.origin + '/api/v1';
+    window.API_BASE = 'https://uurrooster-app.onrender.com/api/v1';
 }
 
 window.DEFAULT_SETTINGS = {


### PR DESCRIPTION
## Probleem

PR #129 brak de login. `window.location.origin + '/api/v1'` wees naar de **frontend**-origin (`vlot-dashboard.site`) i.p.v. de **backend** (`uurrooster-app.onrender.com`). Alle API-calls faalden.

## Fixes

**`frontend/config/settings.js`** — `API_BASE` terug op de hardcoded backend URL:
```
https://uurrooster-app.onrender.com/api/v1
```

**`backend/src/server.js`** — CORS-allowlist uitgebreid zodat requests vanuit `vlot-dashboard.site` (custom frontend-domein) naar de backend worden toegelaten. Ondersteunt ook komma-gescheiden `FRONTEND_URL` env var voor extra flexibiliteit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTLkstjcaGZFP7FZCoD4mX)_