### PR TITLE
UI: verbeter validatiebalk planning tab + dismiss enkel voor beheerders

### DIFF
--- a/frontend/app-init.js
+++ b/frontend/app-init.js
@@ -303,7 +303,7 @@ function setupEventListeners() {
     });
 
     DOM.validationAlerts.addEventListener('click', (event) => {
-        const chip = event.target.closest('.validation-summary-item');
+        const chip = event.target.closest('.validation-chip');
         if (chip) openValidationDetailsModal(chip.dataset.rule || null);
     });
 

--- a/frontend/app-planner.js
+++ b/frontend/app-planner.js
@@ -237,16 +237,33 @@ function renderValidationAlerts() {
     AppState.validationBreakdown = breakdown;
 
     if (breakdown.length > 0) {
-        html += '<div class="validation-summary">';
+        const totalCount = breakdown.reduce((n, b) => n + b.count, 0);
+        const hasErrors = breakdown.some(b => b.isError);
+        const titleIcon = hasErrors ? 'alert-circle' : 'alert-triangle';
+
+        html += `<div class="validation-bar">
+            <div class="validation-bar-header">
+                <span class="validation-bar-title${hasErrors ? ' has-errors' : ''}">
+                    ${IconHelper.html(titleIcon, 'sm')}
+                    <strong>${totalCount}</strong>&nbsp;melding${totalCount !== 1 ? 'en' : ''}
+                </span>
+                <button class="btn btn-xs btn-ghost validation-bar-all" onclick="openValidationDetailsModal(null)">
+                    Alle bekijken ${IconHelper.html('chevron-right', 'xs')}
+                </button>
+            </div>
+            <div class="validation-chips">`;
+
         breakdown.forEach(item => {
             const cfg = VALIDATION_CATEGORY_CONFIG[item.rule.toLowerCase()] ||
                 { icon: item.isError ? 'alert-circle' : 'alert-triangle', label: item.rule, level: item.isError ? 'error' : 'warning' };
-            html += `<div class="validation-summary-item validation-${cfg.level}" data-rule="${escapeHtml(item.rule)}">
+            html += `<button class="validation-chip validation-chip-${cfg.level}" data-rule="${escapeHtml(item.rule)}" title="Klik voor details">
                 ${IconHelper.html(cfg.icon, 'sm')}
-                <span class="validation-text">${escapeHtml(cfg.label)} <strong>${item.count}</strong></span>
-            </div>`;
+                <span>${escapeHtml(cfg.label)}</span>
+                <span class="validation-chip-count">${item.count}</span>
+            </button>`;
         });
-        html += '</div>';
+
+        html += '</div></div>';
     }
 
     DOM.validationAlerts.innerHTML = html;
@@ -304,9 +321,10 @@ function buildIssueBreakdown(summary) {
 
 function renderIssueEntryList(entries) {
     const COLLAPSE_AT = 7;
+    const canDismiss = ['admin', 'roosterverantwoordelijke'].includes(AppState.currentUser?.role);
     const renderEntry = e => `<li class="issue-entry">
         <span class="issue-entry-label">${escapeHtml(e.label)}</span>
-        ${e.key ? `<button class="issue-entry-dismiss btn-ghost" title="Negeren" onclick="dismissFromPlanningTab('${escapeHtml(e.key)}')">${IconHelper.html('eye-off', 'xs')}</button>` : ''}
+        ${e.key && canDismiss ? `<button class="issue-entry-dismiss btn-ghost" title="Negeren" onclick="dismissFromPlanningTab('${escapeHtml(e.key)}')">${IconHelper.html('eye-off', 'xs')}</button>` : ''}
     </li>`;
     if (entries.length <= COLLAPSE_AT) {
         return `<ul class="issue-entry-list">${entries.map(renderEntry).join('')}</ul>`;
@@ -332,14 +350,24 @@ function openValidationDetailsModal(filterRule) {
     const breakdown = (AppState.validationBreakdown || [])
         .filter(item => !filterRule || item.rule === filterRule);
 
+    // Update modal title dynamically
+    const titleEl = DOM.warningDetailsModal.querySelector('.modal-header h2');
+    if (titleEl) {
+        if (filterRule) {
+            const cfg = VALIDATION_CATEGORY_CONFIG[filterRule.toLowerCase()];
+            titleEl.textContent = cfg ? cfg.label : filterRule;
+        } else {
+            titleEl.textContent = 'Validatiemeldingen';
+        }
+    }
+
     DOM.warningDetailsList.innerHTML = breakdown.length === 0
         ? '<p>Geen meldingen voor deze periode.</p>'
         : breakdown.map(item => {
             const cfg = VALIDATION_CATEGORY_CONFIG[item.rule.toLowerCase()] ||
                 { icon: item.isError ? 'alert-circle' : 'alert-triangle', label: item.rule, level: item.isError ? 'error' : 'warning' };
-            const headerClass = `issue-details-level-${cfg.level}`;
-            return `<div class="issue-details-item">
-                <div class="issue-details-header ${headerClass}">
+            return `<div class="issue-details-item issue-details-level-${cfg.level}">
+                <div class="issue-details-header">
                     ${IconHelper.html(cfg.icon, 'sm')}
                     <span class="issue-details-rule">${escapeHtml(cfg.label)}</span>
                     <span class="issue-details-count">${item.count}x</span>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -364,7 +364,7 @@
     <div id="warning-details-modal" class="modal hidden">
         <div class="modal-content">
             <div class="modal-header">
-                <h2>Waarschuwingen</h2>
+                <h2>Validatiemeldingen</h2>
                 <span class="modal-close" id="warning-details-close"><i data-lucide="x"></i></span>
             </div>
             <div class="modal-body">

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1971,90 +1971,140 @@ body[data-view-mode="day"] .timeline-header {
     margin-bottom: 16px;
 }
 
-.validation-summary {
+/* ===== VALIDATION BAR (planning tab) ===== */
+.validation-bar {
     background: var(--surface-color);
     border: 1px solid var(--border-color);
     border-radius: var(--radius-md);
-    padding: 12px 16px;
+    padding: 10px 14px 12px;
+    box-shadow: var(--shadow-sm);
+}
+
+.validation-bar-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 10px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.validation-bar-title {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text-secondary);
+}
+
+.validation-bar-title.has-errors {
+    color: var(--alert-error-text);
+}
+
+.validation-bar-title svg { opacity: 0.8; }
+
+.validation-bar-all {
+    font-size: 12px;
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+    color: var(--text-secondary);
+}
+
+.validation-chips {
     display: flex;
     flex-wrap: wrap;
-    gap: 12px;
+    gap: 8px;
+}
+
+.validation-chip {
+    display: inline-flex;
     align-items: center;
+    gap: 6px;
+    padding: 5px 11px;
+    border-radius: 20px;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    border: 1px solid transparent;
+    background: none;
+    transition: filter 0.15s, box-shadow 0.15s;
+}
+
+.validation-chip:hover {
+    filter: brightness(0.94);
     box-shadow: var(--shadow-sm);
 }
 
-.validation-summary-item {
-    display: flex;
-    align-items: center;
-    gap: var(--space-sm);
-    padding: 6px 12px;
-    border-radius: var(--radius-sm);
-    font-size: 14px;
-    font-weight: 500;
-}
-
-.validation-summary-item.validation-error {
+.validation-chip-error {
     background: var(--alert-error-bg);
     color: var(--alert-error-text);
-    border: 1px solid var(--alert-error-border);
-    cursor: pointer;
+    border-color: var(--alert-error-border);
 }
 
-.validation-summary-item.validation-error:hover {
-    filter: brightness(0.96);
-    box-shadow: var(--shadow-sm);
-}
-
-.validation-summary-item.validation-warning {
+.validation-chip-warning {
     background: var(--alert-warning-bg);
     color: var(--alert-warning-text);
-    border: 1px solid var(--alert-warning-border);
-    cursor: pointer;
+    border-color: var(--alert-warning-border);
 }
 
-.validation-summary-item.validation-warning:hover {
-    filter: brightness(0.96);
-    box-shadow: var(--shadow-sm);
+.validation-chip-count {
+    background: rgba(0, 0, 0, 0.1);
+    border-radius: 10px;
+    padding: 1px 7px;
+    font-size: 11px;
+    font-weight: 700;
+    line-height: 16px;
 }
 
-.validation-icon {
-    font-size: var(--text-md);
-}
+/* Legacy chip classes kept for any residual references */
+.validation-summary { display: flex; flex-wrap: wrap; gap: 8px; }
+.validation-summary-item { display: inline-flex; align-items: center; gap: 6px; padding: 5px 10px; border-radius: 20px; font-size: 13px; font-weight: 500; cursor: pointer; }
+.validation-summary-item.validation-error { background: var(--alert-error-bg); color: var(--alert-error-text); border: 1px solid var(--alert-error-border); }
+.validation-summary-item.validation-warning { background: var(--alert-warning-bg); color: var(--alert-warning-text); border: 1px solid var(--alert-warning-border); }
+.validation-text { font-size: 13px; }
+.validation-summary-note { margin-left: auto; font-size: 12px; color: var(--text-secondary); font-style: italic; }
 
-.validation-text {
-    font-size: 13px;
-}
-
-.validation-summary-note {
-    margin-left: auto;
-    font-size: 12px;
-    color: var(--text-secondary);
-    font-style: italic;
-}
-
+/* ===== VALIDATION DETAILS MODAL CARDS ===== */
 .issue-details-item {
-    padding: 16px;
+    padding: 14px 16px;
     border: 1px solid var(--border-color);
+    border-left: 4px solid var(--border-color);
     border-radius: var(--radius-md);
-    background: #fffaf0;
-    margin-bottom: 12px;
+    background: var(--surface-color);
+    margin-bottom: 10px;
+}
+
+.issue-details-level-error.issue-details-item {
+    border-left-color: var(--color-danger);
+    background: var(--alert-error-bg);
+}
+
+.issue-details-level-warning.issue-details-item {
+    border-left-color: var(--color-warning);
+    background: var(--alert-warning-bg);
 }
 
 .issue-details-header {
     display: flex;
-    justify-content: space-between;
-    align-items: baseline;
+    align-items: center;
+    gap: 8px;
     margin-bottom: 8px;
 }
 
 .issue-details-rule {
     font-weight: 600;
-    color: #92400e;
+    flex: 1;
+    color: var(--text-primary);
 }
 
 .issue-details-count {
     font-size: 12px;
     color: var(--text-secondary);
+    background: rgba(0,0,0,0.06);
+    border-radius: 10px;
+    padding: 1px 8px;
 }
 
 .issue-details-example {
@@ -2102,19 +2152,18 @@ body[data-view-mode="day"] .timeline-header {
 .issue-details-more-list { display: none; margin: 4px 0 0; padding-left: 18px; color: var(--text-secondary); font-size: 12px; }
 .issue-details-more--open .issue-details-more-list { display: block; }
 
-.issue-details-header { gap: 6px; }
 .issue-details-level-error .issue-details-rule { color: #991b1b; }
 .issue-details-level-warning .issue-details-rule { color: #92400e; }
 .issue-details-level-error svg { color: #dc2626; }
 .issue-details-level-warning svg { color: #d97706; }
 
-.issue-entry-list { list-style: none; margin: 0 0 10px; padding: 0; }
+.issue-entry-list { list-style: none; margin: 0 0 6px; padding: 0; }
 .issue-entry {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 8px;
-    padding: 3px 0;
+    padding: 4px 0;
     font-size: 12px;
     color: var(--text-secondary);
     border-bottom: 1px solid var(--border-color);
@@ -2129,7 +2178,7 @@ body[data-view-mode="day"] .timeline-header {
     padding: 2px 4px;
     color: var(--text-muted);
     border-radius: 3px;
-    opacity: 0.5;
+    opacity: 0.45;
     transition: opacity 0.15s;
 }
 .issue-entry-dismiss:hover { opacity: 1; color: var(--text-secondary); }


### PR DESCRIPTION
## Summary

- Nieuwe `.validation-bar` met header (totaaltelling + "Alle bekijken" knop) en pill-shaped chips per categorie
- Kleurgecodeerde linker rand op detailkaarten in de modal (rood = fout, oranje = waarschuwing)
- Modaltitel past zich dynamisch aan op de geselecteerde categorie
- Dismiss-knop enkel zichtbaar voor `admin` en `roosterverantwoordelijke`

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTLkstjcaGZFP7FZCoD4mX)_