### PR TITLE
Fix: geen onderbezettingsmelding op handmatig gesloten dagen

### DIFF
--- a/frontend/validation.js
+++ b/frontend/validation.js
@@ -132,6 +132,7 @@ function validateTeamAssignment(employeeId, teamId) {
 
 function validateMinimumStaffing(date, teamId = null) {
     const warnings = [];
+    if (typeof isDayClosed === 'function' && isDayClosed(date)) return { errors: [], warnings };
     if (typeof getStaffingRulesForDay !== 'function' || typeof calcPlanningHourlyHeadcount !== 'function') {
         return { errors: [], warnings };
     }


### PR DESCRIPTION
Voegt een `isDayClosed`-check toe aan het begin van `validateMinimumStaffing` zodat handmatig gesloten dagen geen onderbezettingswaarschuwingen genereren in de planning tab.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTLkstjcaGZFP7FZCoD4mX)_