### PR TITLE
Fix: geen onderbezettingsmelding voor verleden dagen

### DIFF
--- a/frontend/validation.js
+++ b/frontend/validation.js
@@ -133,6 +133,7 @@ function validateTeamAssignment(employeeId, teamId) {
 function validateMinimumStaffing(date, teamId = null) {
     const warnings = [];
     if (typeof isDayClosed === 'function' && isDayClosed(date)) return { errors: [], warnings };
+    if (date < formatDateYYYYMMDD(new Date())) return { errors: [], warnings };
     if (typeof getStaffingRulesForDay !== 'function' || typeof calcPlanningHourlyHeadcount !== 'function') {
         return { errors: [], warnings };
     }


### PR DESCRIPTION
Slaat datums in het verleden over in `validateMinimumStaffing` zodat er geen onderbezettingswaarschuwingen verschijnen voor al voorbije dagen.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTLkstjcaGZFP7FZCoD4mX)_